### PR TITLE
Fixed URL to access ObjectStorage service

### DIFF
--- a/BluemixObjectStorage.podspec
+++ b/BluemixObjectStorage.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'BluemixObjectStorage'
-  s.version      = '1.0.1'
+  s.version      = '1.0.2'
   s.summary      = 'Bluemix Object Storage SDK'
   s.homepage     = 'https://github.com/ibm-bluemix-mobile-services/bluemix-objectstorage-clientsdk-swift'
   s.license      = 'Apache License, Version 2.0'

--- a/BluemixObjectStorage/HttpClient.swift
+++ b/BluemixObjectStorage/HttpClient.swift
@@ -88,10 +88,10 @@ private extension HttpClient{
         if let headers = headers {
             request.headers = headers
         }
-        let networkRequestCompletionHandler = { (response: Response?, argerr: Error?) -> Void in
-            guard argerr == nil, response != nil else {
+        let networkRequestCompletionHandler = { (response: Response?, error: Error?) -> Void in
+            guard error == nil, response != nil else {
                 self.logger.error(String(describing: HttpError.connectionFailure))
-                self.logger.error(argerr.debugDescription)
+                self.logger.error(error.debugDescription)
                 completionHandler(HttpError.connectionFailure, nil, nil, nil)
                 return
             }

--- a/BluemixObjectStorage/HttpClient.swift
+++ b/BluemixObjectStorage/HttpClient.swift
@@ -88,10 +88,10 @@ private extension HttpClient{
         if let headers = headers {
             request.headers = headers
         }
-        
-        let networkRequestCompletionHandler = { (response: Response?, _: Error?) -> Void in
-            guard response != nil else {
+        let networkRequestCompletionHandler = { (response: Response?, argerr: Error?) -> Void in
+            guard argerr == nil, response != nil else {
                 self.logger.error(String(describing: HttpError.connectionFailure))
+                self.logger.error(argerr.debugDescription)
                 completionHandler(HttpError.connectionFailure, nil, nil, nil)
                 return
             }

--- a/BluemixObjectStorage/HttpResource.swift
+++ b/BluemixObjectStorage/HttpResource.swift
@@ -28,7 +28,7 @@ internal struct HttpResource{
 	
 	var uri:String{
 		get{
-			return schema + "://" + host + ":" + port + path
+		    return schema + "://" + host + path
 		}
 	}
 		

--- a/BluemixObjectStorage/HttpResource.swift
+++ b/BluemixObjectStorage/HttpResource.swift
@@ -1,60 +1,59 @@
 /*
-*     Copyright 2016 IBM Corp.
-*     Licensed under the Apache License, Version 2.0 (the "License");
-*     you may not use this file except in compliance with the License.
-*     You may obtain a copy of the License at
-*     http://www.apache.org/licenses/LICENSE-2.0
-*     Unless required by applicable law or agreed to in writing, software
-*     distributed under the License is distributed on an "AS IS" BASIS,
-*     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*     See the License for the specific language governing permissions and
-*     limitations under the License.
-*/
+ *     Copyright 2016 IBM Corp.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
 /// Used for specifying an Http Resource that the request will be made to
 internal struct HttpResource{
-	
-	/// Request schema, should be either http or https
-	let schema:String
-	
-	/// Resource host name, e.g. www.example.com
-	let host:String
-	
-	/// Resource port, e.g. 80
-	let port:String
-	
-	/// Resource path, e.g. /my/resource/id/123
-	let path:String
-	
-	var uri:String{
-		get{
-		    return schema + "://" + host + path
-		}
-	}
-		
-	/**
-	Initialize the HttpResource by specifying all properties
-	
-	- Parameter schema: Request schema, should be either http or https
-	- Parameter host: Resource host name, e.g. www.example.com
-	- Parameter port: Resource port, e.g. 80
-	- Parameter path: Resource path, e.g. /my/resource/id/123
-	*/
-	
-	internal init(schema:String, host: String, port: String, path: String = "") {
-		self.schema = schema
-		self.host = host
-		self.port = port
-		self.path = path
-	}
-	
-	/**
-	Create a new HttpResource by adding components to path
-	
-	- Parameter pathComponent: components to add
-	*/
-	internal func resourceByAddingPathComponent(pathComponent:String) -> HttpResource {
-		return HttpResource(schema: self.schema, host: self.host, port: self.port, path: self.path + pathComponent)
-	}
+    
+    /// Request schema, should be either http or https
+    let schema:String
+    
+    /// Resource host name, e.g. www.example.com
+    let host:String
+    
+    /// Resource port, e.g. 80
+    let port:String
+    
+    /// Resource path, e.g. /my/resource/id/123
+    let path:String
+    
+    var uri:String{
+        get{
+            return schema + "://" + host + path
+        }
+    }
+    
+    /**
+     Initialize the HttpResource by specifying all properties
+     
+     - Parameter schema: Request schema, should be either http or https
+     - Parameter host: Resource host name, e.g. www.example.com
+     - Parameter port: Resource port, e.g. 80
+     - Parameter path: Resource path, e.g. /my/resource/id/123
+     */
+    
+    internal init(schema:String, host: String, port: String, path: String = "") {
+        self.schema = schema
+        self.host = host
+        self.port = port
+        self.path = path
+    }
+    
+    /**
+     Create a new HttpResource by adding components to path
+     
+     - Parameter pathComponent: components to add
+     */
+    internal func resourceByAddingPathComponent(pathComponent:String) -> HttpResource {
+        return HttpResource(schema: self.schema, host: self.host, port: self.port, path: self.path + pathComponent)
+    }
 }
-


### PR DESCRIPTION
The [Bluemix Object Storage](https://console.bluemix.net/catalog/services/object-storage) service was recently updated such that it no longer accepts requests that include a port in the request URL. These updates remove the port from the request URL, and fix a couple of minor style/syntax issues.